### PR TITLE
fix: remove uneeded files from package bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,18 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "files": [
+    "cli.js",
+    "src",
+    "dist"
+  ],
+  "typesVersions": {
+    "*": {
+      "*": [
+        "*",
+        "dist/*"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Skip adding files we dont need when publishing the npm package

License: MIT